### PR TITLE
Allowing negative line numbers in head

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,10 @@ Head
     tailhead.head(open('test.txt', 'rb'), 3)
     # [b'Line 1', b'Line 2', b'Line 3']
 
+    # Get all lines but last 6 lines of the file
+    tailhead.head(open('test.txt', 'rb'), -6)
+    # [b'Line 1', b'Line 2', b'Line 3', b'Line 4', b'Line 5']
+
 Follow
 ------
 ::

--- a/tailhead/__init__.py
+++ b/tailhead/__init__.py
@@ -223,11 +223,17 @@ class Tailer(object):
         """
         Return the top lines of the file.
         """
-        self.file.seek(0)
 
-        for i in range(lines):
-            if self.seek_next_line() == -1:
-                break
+        if lines < 0:
+            self.file.seek(0, SEEK_END)
+            for i in range(-lines):
+                if self.seek_previous_line() == -1:
+                    break
+        else:
+            self.file.seek(0)
+            for i in range(lines):
+                if self.seek_next_line() == -1:
+                    break
     
         end_pos = self.file.tell()
         
@@ -337,7 +343,9 @@ def head(file, lines=10, read_size=1024):
     ...         _ = fw.write('\\r')
     ...         fw.flush()
     ...         head(fr, 6, 1)  # doctest: +ELLIPSIS
+    ...         head(fr, -2, 1)  # doctest: +ELLIPSIS
     [...'', ...'', ...'', ...'Line 1', ...'Line 2', ...'Line 3']
+    [...'', ...'', ...'', ...'Line 1', ...'Line 2', ...'Line 3', ...'Line 4']
     >>> os.remove('test_head.txt')
     """
     return Tailer(file, read_size).head(lines)

--- a/tailhead/__init__.py
+++ b/tailhead/__init__.py
@@ -222,6 +222,8 @@ class Tailer(object):
     def head(self, lines=10):
         """
         Return the top lines of the file.
+        If 'lines' is negative returns all but the last
+        'lines' of the file.
         """
 
         if lines < 0:
@@ -327,6 +329,8 @@ def tail(file, lines=10, read_size=1024):
 def head(file, lines=10, read_size=1024):
     """
     Return the top lines of the file.
+    If 'lines' is negative returns all but the last
+    'lines' of the file.
 
     >>> import io
     >>>


### PR DESCRIPTION
Matches the same functionality UNIX head command allowing negative number of lines.
```
-n, --lines=[-]NUM       print the first NUM lines instead of the first 10;
                         with the leading '-', print all but the last
                         NUM lines of each file
```
